### PR TITLE
Fix serialization error in openapi with PyObjectId

### DIFF
--- a/app/models/collections.py
+++ b/app/models/collections.py
@@ -1,10 +1,6 @@
-from typing import Optional
-import os
-from bson import ObjectId
-from mongoengine import Document, StringField, IntField, DynamicDocument, connect
-from pydantic import BaseModel, Field
-from app.models.pyobjectid import PyObjectId
-from app.models.mongomodel import OID, MongoModel
+from mongoengine import DynamicDocument
+
+from app.models.mongomodel import MongoModel
 
 
 class Collection(MongoModel):

--- a/app/models/datasets.py
+++ b/app/models/datasets.py
@@ -21,7 +21,7 @@ class DatasetStatus(AutoName):
 
 class Dataset(MongoModel):
     name: str = "N/A"
-    author: PyObjectId
+    author: PyObjectId = Field(default_factory=PyObjectId)
     description: str = "N/A"
     created: datetime = Field(default_factory=datetime.utcnow)
     modified: datetime = Field(default_factory=datetime.utcnow)

--- a/app/models/files.py
+++ b/app/models/files.py
@@ -1,14 +1,13 @@
-from typing import Optional
-import os
-from bson import ObjectId
-from mongoengine import Document, StringField, IntField, DynamicDocument, connect
-from pydantic import BaseModel, Field
+from mongoengine import DynamicDocument
+from mongoengine import DynamicDocument
+from pydantic import Field
+
+from app.models.mongomodel import MongoModel
 from app.models.pyobjectid import PyObjectId
-from app.models.mongomodel import OID, MongoModel
 
 
 class ClowderFile(MongoModel):
-    creator: PyObjectId = PyObjectId("000000000000000000000000")
+    creator: PyObjectId = Field(default_factory=PyObjectId)
     name: str = "_NA_"
     views: int = 0
     downloads: int = 0

--- a/app/models/items.py
+++ b/app/models/items.py
@@ -1,10 +1,8 @@
 from typing import Optional
 
-from bson import ObjectId
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 from app.models.mongomodel import MongoModel
-from app.models.pyobjectid import PyObjectId
 
 
 class NestedValue(BaseModel):

--- a/app/models/users.py
+++ b/app/models/users.py
@@ -1,13 +1,8 @@
-from pydantic import Field
-from typing import Optional
-import os
-from bson import ObjectId
-from mongoengine import Document, StringField, IntField, DynamicDocument, connect
-from pydantic import BaseModel, Field
-from app.models.pyobjectid import PyObjectId
-from app.models.mongomodel import OID, MongoModel
-from passlib.context import CryptContext
 from mongoengine import connect
+from passlib.context import CryptContext
+from pydantic import BaseModel, Field
+
+from app.models.mongomodel import MongoModel
 
 DATABASE_URI = "mongodb://127.0.0.1:27017"
 db = DATABASE_URI + "/clowder"


### PR DESCRIPTION
PyObjectId in any models needs to have a default_factory for the swagger `/docs` to work. 

For example `author: PyObjectId = Field(default_factory=PyObjectId)`