### PR TITLE
Fixed dataset tests.

### DIFF
--- a/app/models/datasets.py
+++ b/app/models/datasets.py
@@ -21,7 +21,7 @@ class DatasetStatus(AutoName):
 
 class Dataset(MongoModel):
     name: str = "N/A"
-    author: PyObjectId
+    author: PyObjectId = Field(default_factory=PyObjectId)
     description: str = "N/A"
     created: datetime = Field(default_factory=datetime.utcnow)
     modified: datetime = Field(default_factory=datetime.utcnow)

--- a/app/routers/datasets.py
+++ b/app/routers/datasets.py
@@ -15,9 +15,9 @@ router = APIRouter()
 auth_handler = AuthHandler()
 
 
-@router.post("/datasets")
+@router.post("/datasets", response_model=Dataset)
 async def save_dataset(
-    dataset_info: Json[Dataset],
+    dataset_info: Dataset,
     user_id=Depends(auth_handler.auth_wrapper),
     db: MongoClient = Depends(dependencies.get_db),
 ):
@@ -26,7 +26,6 @@ async def save_dataset(
     ds["author"] = user["_id"]
     new_dataset = await db["datasets"].insert_one(ds)
     found = await db["datasets"].find_one({"_id": new_dataset.inserted_id})
-
     return Dataset.from_mongo(found)
 
 
@@ -84,7 +83,7 @@ async def edit_dataset(
     raise HTTPException(status_code=404, detail=f"Dataset {dataset_id} not found")
 
 
-@router.delete("/datasets/delete/{dataset_id}")
+@router.delete("/datasets/{dataset_id}")
 async def delete_dataset(
     dataset_id: str, db: MongoClient = Depends(dependencies.get_db)
 ):

--- a/app/tests/test_datasets.py
+++ b/app/tests/test_datasets.py
@@ -1,10 +1,12 @@
+import json
+
 from fastapi.testclient import TestClient
 
 from app.main import app
 
 client = TestClient(app)
 
-dataset = {
+dataset_data = {
     "name": "first dataset",
     "description": "a dataset is a container of files and metadata",
     "views": 0,
@@ -21,10 +23,11 @@ def test_create():
     assert response.status_code == 200
     token = response.json().get("token")
     assert token is not None
-    headers = {"Authorization": "Bearer " + token}
-    response = client.post("/datasets", json=dataset, headers=headers)
-    assert response.json().get("id") is not None
+    print(f"\nAccess Token: {token}\n")
+    headers = {"Authorization": f"Bearer {token}"}
+    response = client.post("/datasets", headers=headers, json=dataset_data)
     assert response.status_code == 200
+    assert response.json().get("id") is not None
 
 
 def test_get_one():
@@ -32,10 +35,11 @@ def test_get_one():
     assert response.status_code == 200
     token = response.json().get("token")
     assert token is not None
-    headers = {"Authorization": "Bearer " + token}
-    response = client.post("/datasets", json=dataset, headers=headers)
-    assert response.json().get("id") is not None
+    print(f"\nAccess Token: {token}\n")
+    headers = {"Authorization": f"Bearer {token}"}
+    response = client.post("/datasets", headers=headers, json=dataset_data)
     assert response.status_code == 200
+    assert response.json().get("id") is not None
     dataset_id = response.json().get("id")
     response = client.get(f"/datasets/{dataset_id}")
     assert response.status_code == 200
@@ -47,11 +51,12 @@ def test_delete():
     assert response.status_code == 200
     token = response.json().get("token")
     assert token is not None
-    headers = {"Authorization": "Bearer " + token}
-    response = client.post("/datasets", json=dataset, headers=headers)
-    assert response.json().get("_id") is not None
+    headers = {"Authorization": f"Bearer {token}"}
+    response = client.post("/datasets", headers=headers, json=dataset_data)
     assert response.status_code == 200
-    response = client.delete("/datasets", headers=headers)
+    assert response.json().get("id") is not None
+    dataset_id = response.json().get("id")
+    response = client.delete(f"/datasets/{dataset_id}", headers=headers)
     assert response.status_code == 200
 
 
@@ -61,14 +66,14 @@ def test_edit():
     token = response.json().get("token")
     assert token is not None
     headers = {"Authorization": "Bearer " + token}
-    response = client.post("/datasets", json=dataset, headers=headers)
-    assert response.json().get("_id") is not None
+    response = client.post("/datasets", json=dataset_data, headers=headers)
     assert response.status_code == 200
+    assert response.json().get("id") is not None
     new_dataset = response.json()
     new_dataset["name"] = "edited name"
     response = client.post("/datasets", json=new_dataset, headers=headers)
-    assert response.json().get("_id") is not None
     assert response.status_code == 200
+    assert response.json().get("id") is not None
 
 
 def test_list():
@@ -77,13 +82,9 @@ def test_list():
     token = response.json().get("token")
     assert token is not None
     headers = {"Authorization": "Bearer " + token}
-    response = client.post("/datasets", json=dataset, headers=headers)
-    assert response.json().get("id") is not None
+    response = client.post("/datasets", json=dataset_data, headers=headers)
     assert response.status_code == 200
+    assert response.json().get("id") is not None
     response = client.get("/datasets", headers=headers)
     assert response.status_code == 200
     assert len(response.json()) > 0
-
-
-if __name__ == "__main__":
-    test_edit()


### PR DESCRIPTION
Parameter type needs to be `Dataset` and not `JSON[Dataset]`.
PyDatasetId needs to have a `default_factory`.
API now returns `id` instead of `_id`.
Delete method test was missing URL parameters.